### PR TITLE
chore: Add features of `cargo`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,11 @@ dialoguer = "0.11"
 port-selector = "0.1"
 hyper-util = { version = "0.1.1", features = ["full"] }
 
+[features]
+vendored-openssl = ["cargo/vendored-openssl"]
+vendored-libgit2 = ["cargo/vendored-libgit2"]
+all-static = ["cargo/all-static"]
+
 [badges]
 travis-ci = { repository = "btwiuse/cargo-docs", branch = "master" }
 maintenance = { status = "experimental" }


### PR DESCRIPTION
### Description
This PR enables user to enable cargo's features such as `vendored-libgit2`, `vendored-openssl`.

### Why
`cargo-docs` depends on `cargo` crate, and it depends on `git2` crate.
`git2` uses library named `libgit2`, and give us options:

- compile and statically link to a copy of `libgit2` (`vendored-libgit2` feature)
- use installed `libgit2` on system

But, we cannot use `libgit2` on system in some environment, such as WSL2.

At least on my environment, I did `cargo install cargo-docs` and run cargo-docs, but I got following error:
```
target/debug/cargo-docs: error while loading shared libraries: libgit2.so.1.7: cannot open shared object file: No such file or directory
```

So I had to enable `vendored-libgit2` feature.


(I'm Japanese student learning English so please forgive me if my English includes any mistakes ;)

